### PR TITLE
Fix tours.json on unix

### DIFF
--- a/Classes/Tour.cs
+++ b/Classes/Tour.cs
@@ -109,7 +109,7 @@ public class Tour
 
             // Write the list of tours to a JSON file
             var manager = new ReservationSystem.jsonManager();
-            manager.writeToJson(tours, @"JsonFiles\tours.json");
+            manager.writeToJson(tours, @"JsonFiles/tours.json");
         }
     }
 


### PR DESCRIPTION
This fixes a backslash on unix-like devices. 