### PR TITLE
(TD-90 & TD-95) Show only free places on tour and show the day/date less

### DIFF
--- a/Classes/Reservation.cs
+++ b/Classes/Reservation.cs
@@ -35,7 +35,7 @@ namespace ReservationSystem
                             tourFound = true;
 
                             TourCheckReturn.Add(new (){text = "De Rondleiding die u heeft geboekt: \n"});
-                            TourCheckReturn.Add(new (){text = checkTour.dateTime.ToString()});
+                            TourCheckReturn.Add(new (){text = checkTour.dateTime.ToString("HH:mm")});
                             TourCheckReturn.Add(new (){text = "Rondleiding duur: " + checkTour.tourDuration.ToString() + " min",hasExtraBreak = true});
                             
                             TourCheckReturn.Add(new(){
@@ -61,7 +61,7 @@ namespace ReservationSystem
                                             actions.Add(
                                                 new()
                                                 {
-                                                    text = $"{tour.dateTime.ToShortTimeString()} - {tour.dateTime.AddMinutes(tour.tourDuration).ToShortTimeString()} ({(isStarted ? "Tour al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} van de {tour.maxBookingCount} plaatsen vrij")})",
+                                                    text = $"{tour.dateTime.ToString("HH:mm")} - {tour.dateTime.AddMinutes(tour.tourDuration).ToShortTimeString()} ({(isStarted ? "Tour al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} plaatsen vrij")})",
                                                     onAction = line =>
                                                     {
                                                         changeReservations.moveReservation(tour, checkTour, reservation, tickets);

--- a/Classes/makeReservation.cs
+++ b/Classes/makeReservation.cs
@@ -118,7 +118,7 @@ class makeReservation
                                 }
                             };
 
-                            invalidReservation($"U heeft al een reservering staan ({checkTour.dateTime})", tour, extraAction, false);
+                            invalidReservation($"U heeft al een reservering staan ({checkTour.dateTime.ToString("HH:mm")})", tour, extraAction, false);
                         }
                     }
                 }
@@ -153,12 +153,12 @@ class makeReservation
 
                 actions = new List<Action> {
                     new() {
-                        text = $"Uw reservering is gelukt: ({tour.dateTime})",
+                        text = $"Uw reservering is gelukt: ({tour.dateTime.ToString("HH:mm")})",
                         hasExtraBreak = true,
                         textType = TextType.Success
                     },
                     new() {
-                    text = $"Nog een reservering maken voor deze tour ({tour.dateTime})",
+                    text = $"Nog een reservering maken voor deze tour ({tour.dateTime.ToString("HH:mm")})",
                     hasExtraBreak = false,
                     onAction = line => {
                         if (!makeReservation.getUsersTicketAndMakeReservation(tour))
@@ -191,7 +191,7 @@ class makeReservation
     public static bool getUsersTicketAndMakeReservation(Tour tour)
     {
 
-        Console.WriteLine($"Scan nu uw ticket om deze tour te boeken ({tour.dateTime})");
+        Console.WriteLine($"Scan nu uw ticket om deze tour te boeken ({tour.dateTime.ToString("HH:mm")})");
         string ticketID = ProgramManger.readLine();
         if (ticketID != "")
         {

--- a/Program.cs
+++ b/Program.cs
@@ -164,7 +164,7 @@ namespace ReservationSystem
                 actions.Add(
                     new()
                     {
-                        text = $"{tour.dateTime.ToShortTimeString()} - {tour.dateTime.AddMinutes(tour.tourDuration).ToShortTimeString()} ({(isStarted ? "Tour al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} van de {tour.maxBookingCount} plaatsen vrij")})",
+                        text = $"{tour.dateTime.ToShortTimeString()} - {tour.dateTime.ToString("HH:mm")} ({(isStarted ? "Tour al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} plaatsen vrij")})",
                         textType = isFull || isStarted ? TextType.Error : TextType.Normal,
                         onAction = hasActions ? line =>
                         {
@@ -206,7 +206,7 @@ namespace ReservationSystem
                 },
                 new()
                 {
-                    text = $"{tour.dateTime.ToShortTimeString()} - {tour.dateTime.AddMinutes(tour.tourDuration).ToShortTimeString()}\n{(isStarted? "Tour is al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} van de {tour.maxBookingCount} plaatsen vrij")}",
+                    text = $"{tour.dateTime.ToShortTimeString()} - {tour.dateTime.ToString("HH:mm")}\n{(isStarted? "Tour is al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} plaatsen vrij")}",
                     hasExtraBreak = true,
 
                 }

--- a/Program.cs
+++ b/Program.cs
@@ -164,7 +164,7 @@ namespace ReservationSystem
                 actions.Add(
                     new()
                     {
-                        text = $"{tour.dateTime.ToShortTimeString()} - {tour.dateTime.ToString("HH:mm")} ({(isStarted ? "Tour al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} plaatsen vrij")})",
+                        text = $"{tour.dateTime.ToString("HH:mm")} - {tour.dateTime.AddMinutes(tour.tourDuration).ToString("HH:mm")} ({(isStarted ? "Tour al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} plaatsen vrij")})",
                         textType = isFull || isStarted ? TextType.Error : TextType.Normal,
                         onAction = hasActions ? line =>
                         {
@@ -206,7 +206,7 @@ namespace ReservationSystem
                 },
                 new()
                 {
-                    text = $"{tour.dateTime.ToShortTimeString()} - {tour.dateTime.ToString("HH:mm")}\n{(isStarted? "Tour is al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} plaatsen vrij")}",
+                    text = $"{tour.dateTime.ToString("HH:mm")} - {tour.dateTime.AddMinutes(tour.tourDuration).ToString("HH:mm")}\n{(isStarted? "Tour is al gestart" : isFull ? "Volgeboekt" : $"{freePlaces} plaatsen vrij")}",
                     hasExtraBreak = true,
 
                 }


### PR DESCRIPTION
Fixes two issues:

1. (TD-90) Only show free places (13 plaatsen vrij) instead of free places of total places (13 van de 13 plaatsen vrij).
2. (TD-95) Only show the date once on the home screen.

This is how the home screen look now:
![image](https://user-images.githubusercontent.com/45796066/234648290-cce1814a-dcab-4851-8930-135abd5f8014.png)
